### PR TITLE
chore: bump version to 1.2512.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dewdew-world",
   "type": "module",
-  "version": "1.2512.5",
+  "version": "1.2512.6",
   "scripts": {
     "dev": "astro dev --port 4001",
     "start": "astro dev",

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -77,7 +77,6 @@ const schemaData = schema || defaultWebsiteSchema
 <link rel='icon' type='image/svg+xml' href='/favicon.svg' />
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="canonical" href={Astro.url.href} />
-<link rel="sitemap" href="/sitemap-index.xml" />
 <link rel='manifest' href='/site.webmanifest' />
 <link rel='mask-icon' href='/images/safari-pinned-tab.svg' color='#5bbad5' />
 <link rel='mask-icon' href='/images/safari-pinned-tab.svg' color='#5bbad5' />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,7 +20,7 @@ const defaultLocale = DEFAULT_LOCALE;
     <meta charset="UTF-8" />
     <title>redirect...</title>
     <ClientRouter fallback="swap" />
-    <link rel="sitemap" href="/sitemap-index.xml" />
+    <link rel="canonical" href={Astro.site?.origin + "/en/"} />
     <meta name="generator" content={Astro.generator} />
     {
       getLocalePaths(Astro.url).map((props) => (

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,13 @@
       "destination": "/ads.txt"
     }
   ],
+  "redirects": [
+    {
+      "source": "/",
+      "destination": "/en/",
+      "permanent": false
+    }
+  ],
   "buildCommand": "bun run build",
   "outputDirectory": "dist"
 }


### PR DESCRIPTION
304-update-module-and-usages-ect
v1.2512.6
1. 루트 경로(/)에 서버 사이드 리디렉션 추가 (vercel.json)
2. index.astro에 canonical URL 추가
3. Head.astro에서 표준이 아닌 사이트맵 링크 제거
4. Google Search Console 색인 생성 문제 해결"